### PR TITLE
change/cross-fetch

### DIFF
--- a/common-js/Biconomy.js
+++ b/common-js/Biconomy.js
@@ -46,7 +46,7 @@ var _require4 = require("./abis"),
     biconomyForwarderAbi = _require4.biconomyForwarderAbi,
     transferHandlerAbi = _require4.transferHandlerAbi;
 
-var fetch = require("node-fetch");
+var fetch = require("cross-fetch");
 
 var decoderMap = {},
     smartContractMap = {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/mexa",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Mexa SDK to enable meta transaction in your DApps",
   "main": "common-js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "@babel/core": "^7.12.13",
     "@babel/runtime": "^7.12.13",
     "abi-decoder": "^2.2.2",
+    "cross-fetch": "^3.1.4",
     "ethereum-tx-decoder": "^3.0.0",
     "ethereumjs-abi": "^0.6.8",
     "ethers": "^5.0.24",
     "events": "^3.0.0",
-    "node-fetch": "^2.6.0",
     "promise": "^8.0.3"
   },
   "engines": {

--- a/src/Biconomy.js
+++ b/src/Biconomy.js
@@ -26,7 +26,7 @@ let {
   transferHandlerAbi,
 } = require("./abis");
 
-let fetch = require("node-fetch");
+let fetch = require("cross-fetch");
 
 let decoderMap = {},
   smartContractMap = {},


### PR DESCRIPTION
This PR enables users with Webpack to prevent using node polyfills for FE applications while maintaining functionality on BE.

`cross-fetch` should have the same API as `node-fetch`, as it's a universal WHATWG Fetch API.

As they state in their [npm package](https://www.npmjs.com/package/cross-fetch) description:

> For Node, Browsers and React Native. The scenario that cross-fetch really shines is when the same JavaScript codebase needs to run on different platforms.
> 
> Platform agnostic: browsers, Node or React Native
> Optional polyfill: it's up to you if something is going to be added to the global object or not
> Simple interface: no instantiation, no configuration and no extra dependency
> WHATWG compliant: it works the same way wherever your code runs
> TypeScript support: better development experience with types.