### PR TITLE
Abi decoder hotfix 

### DIFF
--- a/common-js/Biconomy.js
+++ b/common-js/Biconomy.js
@@ -1854,6 +1854,11 @@ function _getParamValue(paramObj) {
   var value;
 
   try {
+    if (paramObj && paramObj.type == "bytes" && (!paramObj.value || paramObj.value == undefined || paramObj.value == null)) {
+      value = "0x";
+      return value;
+    }
+
     if (paramObj && paramObj.value) {
       var type = paramObj.type;
 

--- a/common-js/Biconomy.js
+++ b/common-js/Biconomy.js
@@ -1513,7 +1513,18 @@ function getSignatureEIP712(engine, account, request) {
                 if (error) {
                   reject(error);
                 } else {
-                  resolve(res.result);
+                  var oldSignature = res.result;
+
+                  var _getSignatureParamete2 = getSignatureParameters(oldSignature),
+                      _r = _getSignatureParamete2.r,
+                      _s = _getSignatureParamete2.s,
+                      _v = _getSignatureParamete2.v;
+
+                  _v = ethers.BigNumber.from(_v).toHexString();
+
+                  var _newSignature = _r + _s.slice(2) + _v.slice(2);
+
+                  resolve(_newSignature);
                 }
               });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/mexa",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Mexa SDK to enable meta transaction in your DApps",
   "main": "common-js/index.js",
   "scripts": {

--- a/src/Biconomy.js
+++ b/src/Biconomy.js
@@ -1412,6 +1412,10 @@ function _validate(options) {
  function _getParamValue(paramObj) {
   var value;
   try {
+    if (paramObj && paramObj.type == "bytes" && (!paramObj.value || paramObj.value == undefined || paramObj.value == null)) {
+      value = "0x";
+      return value;
+    }
     if (paramObj && paramObj.value) {
       let type = paramObj.type;
       switch (type) {

--- a/src/Biconomy.js
+++ b/src/Biconomy.js
@@ -1157,7 +1157,11 @@ function getSignatureEIP712(engine, account, request) {
             if (error) {
               reject(error);
             } else {
-              resolve(res.result);
+              let oldSignature = res.result;
+              let { r, s, v } = getSignatureParameters(oldSignature);
+              v = ethers.BigNumber.from(v).toHexString();
+              let newSignature = r + s.slice(2) + v.slice(2);
+              resolve(newSignature);
             }
           }
         );


### PR DESCRIPTION
If any of the parameter type is bytes in function signature and if its passed empty '0x' (when its optional sometimes) , it gets sanitized to null by abi decoder. 

this work around hotfix does change it to 0x instead of undefined or null. 